### PR TITLE
Update to support new vault path in Ansible 2.0

### DIFF
--- a/ansible_vault/api.py
+++ b/ansible_vault/api.py
@@ -1,5 +1,9 @@
 import yaml
-from ansible.utils.vault import VaultLib
+try:
+    from ansible.utils.vault import VaultLib
+except ImportError:
+    # Ansible 2.0 has changed the vault location
+    from ansible.parsing.vault import VaultLib
 
 
 class Vault(object):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def _read(fname):
 
 setup(
     name='ansible-vault',
-    version='1.0.3',
+    version='1.0.4',
     author='Tomohiro NAKAMURA',
     author_email='quickness.net@gmail.com',
     url='https://github.com/jptomo/ansible-vault',


### PR DESCRIPTION
Ansible 2.0 (currently in beta) has changed the path for the [VaultLib](https://github.com/ansible/ansible/blob/v2.0.0-0.3.beta1/lib/ansible/parsing/vault/__init__.py). 

This fix maintains compatibility, and only tries to load the new path if the old one fails.